### PR TITLE
feat: add CI/CD pipeline and fix GHCR org references

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,82 @@
+name: CI
+
+on:
+  pull_request:
+    branches: [main]
+  push:
+    branches: [main]
+    tags: ["v*"]
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  typecheck:
+    name: Type Check
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+      - uses: pnpm/action-setup@v4
+        with:
+          version: 9
+      - uses: actions/setup-node@v6
+        with:
+          node-version: 20
+          cache: pnpm
+      - run: pnpm install --frozen-lockfile
+      - run: pnpm lint
+
+  test:
+    name: Test
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+      - uses: pnpm/action-setup@v4
+        with:
+          version: 9
+      - uses: actions/setup-node@v6
+        with:
+          node-version: 20
+          cache: pnpm
+      - run: pnpm install --frozen-lockfile
+      - run: pnpm test
+
+  docker:
+    name: Docker
+    needs: [typecheck, test]
+    if: github.event_name == 'push'
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+    steps:
+      - uses: actions/checkout@v6
+
+      - uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - uses: docker/metadata-action@v5
+        id: meta
+        with:
+          images: ghcr.io/redbark-co/actual-sync
+          tags: |
+            type=raw,value=latest,enable={{is_default_branch}}
+            type=sha,prefix=sha-,format=short
+            type=semver,pattern={{version}}
+            type=semver,pattern={{major}}.{{minor}}
+            type=semver,pattern={{major}}
+
+      - uses: docker/setup-buildx-action@v3
+
+      - uses: docker/build-push-action@v6
+        with:
+          context: .
+          push: true
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+          cache-from: type=gha
+          cache-to: type=gha,mode=max

--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ Supports all Redbark banking providers: Fiskil (AU), Akahu (NZ), SnapTrade (glob
 # List your Redbark accounts
 docker run --rm \
   -e REDBARK_API_KEY=rbk_live_... \
-  ghcr.io/redbark/actual-sync:latest \
+  ghcr.io/redbark-co/actual-sync:latest \
   --list-redbark-accounts
 
 # List your Actual Budget accounts
@@ -36,7 +36,7 @@ docker run --rm \
   -e ACTUAL_PASSWORD=your-password \
   -e ACTUAL_BUDGET_ID=your-budget-sync-id \
   -v actual-sync-data:/app/data \
-  ghcr.io/redbark/actual-sync:latest \
+  ghcr.io/redbark-co/actual-sync:latest \
   --list-actual-accounts
 ```
 
@@ -56,19 +56,19 @@ ACCOUNT_MAPPING=redbark-acc-id:actual-acc-id,redbark-acc-id-2:actual-acc-id-2
 # Preview first (no changes written)
 docker run --rm --env-file .env \
   -v actual-sync-data:/app/data \
-  ghcr.io/redbark/actual-sync:latest --dry-run
+  ghcr.io/redbark-co/actual-sync:latest --dry-run
 
 # Run for real
 docker run --rm --env-file .env \
   -v actual-sync-data:/app/data \
-  ghcr.io/redbark/actual-sync:latest
+  ghcr.io/redbark-co/actual-sync:latest
 ```
 
 ### 5. Schedule
 
 ```bash
 # Cron: sync every 6 hours
-0 */6 * * * docker run --rm --env-file /home/user/.redbark-sync.env -v actual-sync-data:/app/data ghcr.io/redbark/actual-sync:latest >> /var/log/redbark-sync.log 2>&1
+0 */6 * * * docker run --rm --env-file /home/user/.redbark-sync.env -v actual-sync-data:/app/data ghcr.io/redbark-co/actual-sync:latest >> /var/log/redbark-sync.log 2>&1
 ```
 
 ## Configuration
@@ -119,7 +119,7 @@ ACCOUNT_MAPPING=<redbark_id>:<actual_id>,<redbark_id>:<actual_id>
 docker run --rm \
   --env-file .env \
   -v actual-sync-data:/app/data \
-  ghcr.io/redbark/actual-sync:latest
+  ghcr.io/redbark-co/actual-sync:latest
 ```
 
 The `/app/data` volume caches the Actual Budget SQLite database locally. Mount a persistent volume so it doesn't re-download the full budget every run.
@@ -144,7 +144,7 @@ spec:
           restartPolicy: OnFailure
           containers:
             - name: sync
-              image: ghcr.io/redbark/actual-sync:latest
+              image: ghcr.io/redbark-co/actual-sync:latest
               envFrom:
                 - secretRef:
                     name: redbark-actual-sync-secrets

--- a/docker-compose.example.yml
+++ b/docker-compose.example.yml
@@ -1,6 +1,6 @@
 services:
   redbark-actual-sync:
-    image: ghcr.io/redbark/actual-sync:latest
+    image: ghcr.io/redbark-co/actual-sync:latest
     # Or build locally:
     # build: .
     restart: "no"

--- a/package.json
+++ b/package.json
@@ -33,7 +33,7 @@
   "license": "MIT",
   "repository": {
     "type": "git",
-    "url": "https://github.com/redbark/actual-sync"
+    "url": "https://github.com/redbark-co/actual-sync"
   },
   "keywords": [
     "actual-budget",

--- a/src/main.ts
+++ b/src/main.ts
@@ -104,7 +104,7 @@ EXAMPLES:
   redbark-actual-sync --list-actual-accounts
 
 DOCKER:
-  docker run --rm --env-file .env -v sync-data:/app/data ghcr.io/redbark/actual-sync
+  docker run --rm --env-file .env -v sync-data:/app/data ghcr.io/redbark-co/actual-sync
 `)
 }
 


### PR DESCRIPTION
## Summary
- Add GitHub Actions CI/CD workflow with typecheck, test, and Docker build/push jobs
- Docker images are published to `ghcr.io/redbark-co/actual-sync` with `latest`, `sha-*`, and semver tags
- Fix all `ghcr.io/redbark/` references to `ghcr.io/redbark-co/` across README, docker-compose, package.json, and help text

## Test plan
- [ ] Verify CI runs typecheck and test jobs on this PR
- [ ] Merge to main and verify Docker image appears at `ghcr.io/redbark-co/actual-sync` with `latest` and `sha-*` tags
- [ ] `docker pull ghcr.io/redbark-co/actual-sync:latest` works after first main push

🤖 Generated with [Claude Code](https://claude.com/claude-code)