### PR TITLE
fix: correct Docker entrypoint, default API URL, and bump @actual-app…

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,6 +1,6 @@
 # Redbark API
 REDBARK_API_KEY=rbk_live_your_key_here
-REDBARK_API_URL=https://app.redbark.io
+REDBARK_API_URL=https://app.redbark.co
 
 # Actual Budget
 ACTUAL_SERVER_URL=http://localhost:5006

--- a/Dockerfile
+++ b/Dockerfile
@@ -31,5 +31,4 @@ ENV ACTUAL_DATA_DIR=/app/data
 ENV NODE_ENV=production
 
 # Use tini as init process for proper signal handling in Docker
-ENTRYPOINT ["/sbin/tini", "--"]
-CMD ["node", "main.cjs"]
+ENTRYPOINT ["/sbin/tini", "--", "node", "main.cjs"]

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Redbark Actual Sync
 
-Automatically sync bank transactions from [Redbark](https://redbark.io) to your self-hosted [Actual Budget](https://actualbudget.org/) instance.
+Automatically sync bank transactions from [Redbark](https://redbark.co) to your self-hosted [Actual Budget](https://actualbudget.org/) instance.
 
 Ships as a single Docker image. Pull, configure, schedule, done.
 
@@ -17,7 +17,7 @@ Supports all Redbark banking providers: Fiskil (AU), Akahu (NZ), SnapTrade (glob
 
 ### 1. Get a Redbark API Key
 
-1. Log into [Redbark](https://app.redbark.io)
+1. Log into [Redbark](https://app.redbark.co)
 2. Go to **Settings > API Keys**
 3. Create a key and copy it (shown once)
 
@@ -82,7 +82,7 @@ docker run --rm --env-file .env \
 | `ACTUAL_PASSWORD` | Yes | — | Actual Budget server password |
 | `ACTUAL_BUDGET_ID` | Yes | — | Budget sync ID (Settings > Advanced in Actual) |
 | `ACCOUNT_MAPPING` | Yes | — | Account mapping (see below) |
-| `REDBARK_API_URL` | No | `https://app.redbark.io` | Redbark API base URL |
+| `REDBARK_API_URL` | No | `https://app.redbark.co` | Redbark API base URL |
 | `ACTUAL_ENCRYPTION_PASSWORD` | No | — | E2E encryption password if enabled |
 | `ACTUAL_DATA_DIR` | No | `./data` | Local cache directory for Actual's SQLite DB |
 | `SYNC_DAYS` | No | `30` | Number of days of history to sync |

--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
     "clean": "rm -rf dist"
   },
   "dependencies": {
-    "@actual-app/api": "^26.2.0",
+    "@actual-app/api": "^26.3.0",
     "pino": "^9.6.0",
     "zod": "^3.24.2"
   },

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -9,8 +9,8 @@ importers:
   .:
     dependencies:
       '@actual-app/api':
-        specifier: ^26.2.0
-        version: 26.2.0
+        specifier: ^26.3.0
+        version: 26.3.0
       pino:
         specifier: ^9.6.0
         version: 9.14.0
@@ -36,8 +36,8 @@ importers:
 
 packages:
 
-  '@actual-app/api@26.2.0':
-    resolution: {integrity: sha512-Or0694ALXY950jy1A92Wrwqz2qItigsLMtKJgwl7eL16de3sDKw5yOZGEq2W561i16mQqdYTT+810N+y2QXbpA==}
+  '@actual-app/api@26.3.0':
+    resolution: {integrity: sha512-03OG+udLh5GXG4I4AbfcRNhLT35vRfgHtE1JnkWGRwv6nFHY+KckPOmsDAX50fw7Q3vxPA8usHkG3JyGcRYSew==}
     engines: {node: '>=20'}
 
   '@actual-app/crdt@2.1.0':
@@ -686,6 +686,7 @@ packages:
   prebuild-install@7.1.3:
     resolution: {integrity: sha512-8Mf2cbV7x1cXPUILADGI3wuhfqWvtiLA1iclTDbFRZkgRQS0NqsPZphna9V+HyTEadheuPmjaJMsbzKQFOzLug==}
     engines: {node: '>=10'}
+    deprecated: No longer maintained. Please contact the author of the relevant native addon; alternatives are available.
     hasBin: true
 
   process-warning@5.0.0:
@@ -967,7 +968,7 @@ packages:
 
 snapshots:
 
-  '@actual-app/api@26.2.0':
+  '@actual-app/api@26.3.0':
     dependencies:
       '@actual-app/crdt': 2.1.0
       better-sqlite3: 12.6.2

--- a/src/config.test.ts
+++ b/src/config.test.ts
@@ -54,7 +54,7 @@ describe('loadConfig', () => {
 
   it('applies defaults', () => {
     const config = loadConfig(validEnv)
-    expect(config.redbarkApiUrl).toBe('https://app.redbark.io')
+    expect(config.redbarkApiUrl).toBe('https://app.redbark.co')
     expect(config.actualDataDir).toBe('./data')
     expect(config.syncDays).toBe(30)
   })

--- a/src/config.ts
+++ b/src/config.ts
@@ -21,7 +21,7 @@ const accountMappingSchema = z
 
 const configSchema = z.object({
   redbarkApiKey: z.string().min(1, 'REDBARK_API_KEY is required'),
-  redbarkApiUrl: z.string().url().default('https://app.redbark.io'),
+  redbarkApiUrl: z.string().url().default('https://app.redbark.co'),
   actualServerUrl: z.string().min(1, 'ACTUAL_SERVER_URL is required'),
   actualPassword: z.string().min(1, 'ACTUAL_PASSWORD is required'),
   actualBudgetId: z.string().min(1, 'ACTUAL_BUDGET_ID is required'),
@@ -45,7 +45,7 @@ export function loadConfig(overrides?: Partial<Record<string, string>>): Config 
 
   const result = configSchema.safeParse({
     redbarkApiKey: env.REDBARK_API_KEY,
-    redbarkApiUrl: env.REDBARK_API_URL || 'https://app.redbark.io',
+    redbarkApiUrl: env.REDBARK_API_URL || 'https://app.redbark.co',
     actualServerUrl: env.ACTUAL_SERVER_URL,
     actualPassword: env.ACTUAL_PASSWORD,
     actualBudgetId: env.ACTUAL_BUDGET_ID,

--- a/src/main.ts
+++ b/src/main.ts
@@ -82,7 +82,7 @@ ENVIRONMENT VARIABLES:
   ACTUAL_PASSWORD             (required) Actual Budget server password
   ACTUAL_BUDGET_ID            (required) Budget sync ID (Settings > Advanced)
   ACCOUNT_MAPPING             (required) Account mapping (redbark_id:actual_id,...)
-  REDBARK_API_URL             API base URL (default: https://app.redbark.io)
+  REDBARK_API_URL             API base URL (default: https://app.redbark.co)
   ACTUAL_ENCRYPTION_PASSWORD  E2E encryption password (if enabled)
   ACTUAL_DATA_DIR             Local data cache (default: ./data)
   SYNC_DAYS                   Days to sync (default: 30)
@@ -110,12 +110,12 @@ DOCKER:
 
 async function handleListRedbarkAccounts(): Promise<void> {
   const apiKey = process.env.REDBARK_API_KEY
-  const apiUrl = process.env.REDBARK_API_URL || 'https://app.redbark.io'
+  const apiUrl = process.env.REDBARK_API_URL || 'https://app.redbark.co'
 
   if (!apiKey) {
     console.error(
       'ERROR: REDBARK_API_KEY is not set.\n' +
-        '  → Create an API key at https://app.redbark.io/settings/api-keys'
+        '  → Create an API key at https://app.redbark.co/settings/api-keys'
     )
     process.exit(EXIT_CONFIG_ERROR)
   }

--- a/src/redbark-client.ts
+++ b/src/redbark-client.ts
@@ -122,7 +122,7 @@ export class RedbarkClient {
 
         if (response.status === 401) {
           throw new RedbarkApiError(
-            'Redbark API returned 401 Unauthorized. Your API key may be revoked or expired.\n  → Check https://app.redbark.io/settings/api-keys',
+            'Redbark API returned 401 Unauthorized. Your API key may be revoked or expired.\n  → Check https://app.redbark.co/settings/api-keys',
             response.status
           )
         }


### PR DESCRIPTION
  ## Summary
  - Fix Docker entrypoint so CLI flags like `--list-redbark-accounts` work without prefixing `node main.cjs`
  - Fix default API URL from `app.redbark.io` to `app.redbark.co`
  - Bump `@actual-app/api` from `^26.2.0` to `^26.3.0` (includes module resolution fix)