### PR TITLE
fix: migrate to new REST API at api.redbark.co

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,6 +1,6 @@
 # Redbark API
 REDBARK_API_KEY=rbk_live_your_key_here
-REDBARK_API_URL=https://app.redbark.co
+REDBARK_API_URL=https://api.redbark.co
 
 # Actual Budget
 ACTUAL_SERVER_URL=http://localhost:5006

--- a/README.md
+++ b/README.md
@@ -82,7 +82,7 @@ docker run --rm --env-file .env \
 | `ACTUAL_PASSWORD` | Yes | — | Actual Budget server password |
 | `ACTUAL_BUDGET_ID` | Yes | — | Budget sync ID (Settings > Advanced in Actual) |
 | `ACCOUNT_MAPPING` | Yes | — | Account mapping (see below) |
-| `REDBARK_API_URL` | No | `https://app.redbark.co` | Redbark API base URL |
+| `REDBARK_API_URL` | No | `https://api.redbark.co` | Redbark API base URL |
 | `ACTUAL_ENCRYPTION_PASSWORD` | No | — | E2E encryption password if enabled |
 | `ACTUAL_DATA_DIR` | No | `./data` | Local cache directory for Actual's SQLite DB |
 | `SYNC_DAYS` | No | `30` | Number of days of history to sync |

--- a/src/config.test.ts
+++ b/src/config.test.ts
@@ -54,7 +54,7 @@ describe('loadConfig', () => {
 
   it('applies defaults', () => {
     const config = loadConfig(validEnv)
-    expect(config.redbarkApiUrl).toBe('https://app.redbark.co')
+    expect(config.redbarkApiUrl).toBe('https://api.redbark.co')
     expect(config.actualDataDir).toBe('./data')
     expect(config.syncDays).toBe(30)
   })

--- a/src/config.ts
+++ b/src/config.ts
@@ -21,7 +21,7 @@ const accountMappingSchema = z
 
 const configSchema = z.object({
   redbarkApiKey: z.string().min(1, 'REDBARK_API_KEY is required'),
-  redbarkApiUrl: z.string().url().default('https://app.redbark.co'),
+  redbarkApiUrl: z.string().url().default('https://api.redbark.co'),
   actualServerUrl: z.string().min(1, 'ACTUAL_SERVER_URL is required'),
   actualPassword: z.string().min(1, 'ACTUAL_PASSWORD is required'),
   actualBudgetId: z.string().min(1, 'ACTUAL_BUDGET_ID is required'),
@@ -45,7 +45,7 @@ export function loadConfig(overrides?: Partial<Record<string, string>>): Config 
 
   const result = configSchema.safeParse({
     redbarkApiKey: env.REDBARK_API_KEY,
-    redbarkApiUrl: env.REDBARK_API_URL || 'https://app.redbark.co',
+    redbarkApiUrl: env.REDBARK_API_URL || 'https://api.redbark.co',
     actualServerUrl: env.ACTUAL_SERVER_URL,
     actualPassword: env.ACTUAL_PASSWORD,
     actualBudgetId: env.ACTUAL_BUDGET_ID,

--- a/src/main.ts
+++ b/src/main.ts
@@ -82,7 +82,7 @@ ENVIRONMENT VARIABLES:
   ACTUAL_PASSWORD             (required) Actual Budget server password
   ACTUAL_BUDGET_ID            (required) Budget sync ID (Settings > Advanced)
   ACCOUNT_MAPPING             (required) Account mapping (redbark_id:actual_id,...)
-  REDBARK_API_URL             API base URL (default: https://app.redbark.co)
+  REDBARK_API_URL             API base URL (default: https://api.redbark.co)
   ACTUAL_ENCRYPTION_PASSWORD  E2E encryption password (if enabled)
   ACTUAL_DATA_DIR             Local data cache (default: ./data)
   SYNC_DAYS                   Days to sync (default: 30)
@@ -110,23 +110,35 @@ DOCKER:
 
 async function handleListRedbarkAccounts(): Promise<void> {
   const apiKey = process.env.REDBARK_API_KEY
-  const apiUrl = process.env.REDBARK_API_URL || 'https://app.redbark.co'
+  const apiUrl = process.env.REDBARK_API_URL || 'https://api.redbark.co'
 
   if (!apiKey) {
     console.error(
       'ERROR: REDBARK_API_KEY is not set.\n' +
-        '  → Create an API key at https://app.redbark.co/settings/api-keys'
+        '  → Create an API key at https://app.redbark.co/settings/api'
     )
     process.exit(EXIT_CONFIG_ERROR)
   }
 
   const client = new RedbarkClient(apiKey, apiUrl)
-  const connections = await client.listConnections()
+  const [connections, accounts] = await Promise.all([
+    client.listConnections(),
+    client.listAccounts(),
+  ])
+
+  // Group accounts by connectionId
+  const accountsByConnection = new Map<string, typeof accounts>()
+  for (const account of accounts) {
+    const group = accountsByConnection.get(account.connectionId) || []
+    group.push(account)
+    accountsByConnection.set(account.connectionId, group)
+  }
 
   console.log('\nRedbark Accounts:')
   for (const conn of connections) {
     console.log(`  Connection: ${conn.institutionName} (${conn.provider})`)
-    for (const account of conn.accounts) {
+    const connAccounts = accountsByConnection.get(conn.id) || []
+    for (const account of connAccounts) {
       const mask = account.accountNumber ? `  ${account.accountNumber}` : ''
       console.log(
         `    ${account.id}  ${account.name} (${account.type})${mask}`

--- a/src/redbark-client.ts
+++ b/src/redbark-client.ts
@@ -13,18 +13,25 @@ interface TransactionsParams {
   limit?: number
 }
 
-interface TransactionsResponse {
-  transactions: RedbarkTransaction[]
-  cursor: string | null
+interface PaginationInfo {
+  total: number
+  limit: number
+  offset: number
   hasMore: boolean
 }
 
+interface TransactionsResponse {
+  data: RedbarkTransaction[]
+  pagination: PaginationInfo
+}
+
 interface ConnectionsResponse {
-  connections: RedbarkConnection[]
+  data: RedbarkConnection[]
 }
 
 interface AccountsResponse {
-  accounts: RedbarkAccount[]
+  data: RedbarkAccount[]
+  pagination: PaginationInfo
 }
 
 const MAX_RETRIES = 3
@@ -43,44 +50,66 @@ export class RedbarkClient {
   }
 
   async listConnections(): Promise<RedbarkConnection[]> {
-    const data = await this.get<ConnectionsResponse>('/api/v1/connections')
-    return data.connections
+    const data = await this.get<ConnectionsResponse>('/v1/connections')
+    return data.data
   }
 
   async listAccounts(): Promise<RedbarkAccount[]> {
-    const data = await this.get<AccountsResponse>('/api/v1/accounts')
-    return data.accounts
+    const allAccounts: RedbarkAccount[] = []
+    let offset = 0
+    const limit = 200
+
+    do {
+      const query = new URLSearchParams({
+        limit: String(limit),
+        offset: String(offset),
+      })
+
+      const data = await this.get<AccountsResponse>(
+        `/v1/accounts?${query.toString()}`
+      )
+
+      allAccounts.push(...data.data)
+
+      if (!data.pagination.hasMore) break
+      offset += limit
+    } while (true)
+
+    return allAccounts
   }
 
   async getTransactions(
     params: TransactionsParams
   ): Promise<RedbarkTransaction[]> {
     const allTransactions: RedbarkTransaction[] = []
-    let cursor: string | null = null
+    let offset = 0
+    const limit = params.limit ?? 200
 
     do {
       const query = new URLSearchParams({
         connectionId: params.connectionId,
-        limit: String(params.limit ?? 200),
+        limit: String(limit),
+        offset: String(offset),
       })
 
       if (params.accountId) query.set('accountId', params.accountId)
       if (params.from) query.set('from', params.from)
       if (params.to) query.set('to', params.to)
-      if (cursor) query.set('cursor', cursor)
 
       const data = await this.get<TransactionsResponse>(
-        `/api/v1/transactions?${query.toString()}`
+        `/v1/transactions?${query.toString()}`
       )
 
-      allTransactions.push(...data.transactions)
-      cursor = data.cursor
+      allTransactions.push(...data.data)
 
       logger.debug(
-        { page: allTransactions.length, hasMore: data.hasMore },
+        { fetched: allTransactions.length, hasMore: data.pagination.hasMore },
         'Fetched transaction page'
       )
-    } while (cursor)
+
+      if (!data.pagination.hasMore) break
+      offset += limit
+    } while (true)
 
     return allTransactions
   }

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,23 +1,24 @@
 export interface RedbarkConnection {
   id: string
   provider: string
+  category: string
+  institutionId: string
   institutionName: string
-  institutionLogo?: string
+  institutionLogo: string | null
   status: string
-  accounts: RedbarkAccount[]
+  lastRefreshedAt: string | null
+  createdAt: string
 }
 
 export interface RedbarkAccount {
   id: string
   connectionId: string
-  provider: string
+  provider: string | null
   name: string
   type: string
-  institutionName: string
-  accountNumber?: string
-  balance?: string
-  availableBalance?: string
-  currency?: string
+  institutionName: string | null
+  accountNumber: string | null
+  currency: string
 }
 
 export interface RedbarkTransaction {
@@ -49,8 +50,14 @@ export interface SyncResult {
   errors: number
 }
 
+export interface PaginationInfo {
+  total: number
+  limit: number
+  offset: number
+  hasMore: boolean
+}
+
 export interface PaginatedResponse<T> {
   data: T[]
-  cursor: string | null
-  hasMore: boolean
+  pagination: PaginationInfo
 }


### PR DESCRIPTION
## Summary
- Update base URL default from `app.redbark.co` to `api.redbark.co`
- Change API path prefix from `/api/v1/` to `/v1/`
- Migrate from cursor-based to offset-based pagination (`limit`/`offset`)
- Update response parsing from named arrays (`{ accounts: [...] }`) to `{ data: [...], pagination: {...} }`
- Update `RedbarkConnection` type (remove nested `accounts[]`, add `category`, `institutionId`, `lastRefreshedAt`, `createdAt`)
- Update `RedbarkAccount` type (nullable fields, remove `balance`/`availableBalance`)
- Update `handleListRedbarkAccounts()` to fetch connections and accounts separately

All 24 tests pass. Type checks clean.

## Test plan
- [ ] Run `pnpm test` — all 24 tests pass
- [ ] Run `pnpm lint` — no type errors
- [ ] Test `--list-redbark-accounts` with a live API key
- [ ] Test a full sync with `--dry-run`