### PR TITLE
Add arm64 docker builds

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -76,6 +76,7 @@ jobs:
         with:
           context: .
           push: true
+          platforms: linux/amd64,linux/arm64
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
           cache-from: type=gha


### PR DESCRIPTION
Hi, Redbark is looking really good for my budgeting.
Just wanted to update the CI tool to spit out arm64 builds too, for Mac M series, but also raspberry pis and etc.

Thanks!

Sorry, had to recreate on a non-main branch so I could test other fixes/etc