### PR TITLE
fix: clear error when server is newer than bundled API and runtime download fails

### DIFF
--- a/README.md
+++ b/README.md
@@ -189,6 +189,7 @@ Actual Budget updates frequently and the sync protocol can break between client/
 | 1 | Sync completed with errors (some transactions failed) |
 | 2 | Configuration error (missing env vars, invalid mapping) |
 | 3 | Connection error (cannot reach Redbark or Actual) |
+| 4 | Actual server version is newer than the bundled API and no matching version could be downloaded (upgrade this container) |
 
 ## Security
 

--- a/src/actual-client.ts
+++ b/src/actual-client.ts
@@ -22,7 +22,7 @@ export class ApiVersionMismatchError extends Error {
       [
         `Actual Budget server is on ${serverVersion}, but this container ships @actual-app/api ${bundledVersion}.`,
         `Tried to download a matching API at runtime, but it failed: ${downloadError}.`,
-        `Refusing to open the budget with the older bundled API — that would produce an "out-of-sync-migrations" error and could corrupt data.`,
+        `Not falling back to the bundled API because it is older than the server — if the budget contains migrations only the server knows, @actual-app/api will refuse to open it with "out-of-sync-migrations".`,
         `Fix: upgrade this container to a newer redbark-co/actual-sync image, or pin your Actual server to ${bundledVersion}.`,
       ].join(' ')
     )
@@ -188,39 +188,43 @@ async function loadActualApi(
         'Actual Budget server version differs from bundled API'
       )
 
+      const serverIsNewer = compareSemver(serverVersion, bundledVersion) > 0
       const { path: matchingPath, error: downloadError } = downloadMatchingApi(
         serverVersion,
         dataDir
       )
+
       if (matchingPath) {
         try {
           return require(matchingPath) as typeof import('@actual-app/api')
         } catch (error) {
-          throw new ApiVersionMismatchError(
-            serverVersion,
-            bundledVersion,
-            `loaded downloaded API at ${matchingPath} but require() failed: ${String(error)}`
+          // Server newer than bundled → bundled cannot open the DB without
+          // hitting @actual-app/api's out-of-sync-migrations guard. Surface
+          // the version mismatch instead of letting that opaque error fire.
+          if (serverIsNewer) {
+            throw new ApiVersionMismatchError(
+              serverVersion,
+              bundledVersion,
+              `loaded downloaded API at ${matchingPath} but require() failed: ${String(error)}`
+            )
+          }
+          logger.warn(
+            { error: String(error) },
+            'Failed to load downloaded API, using bundled version'
           )
         }
-      }
-
-      // Download failed. Bundled API can still safely open a budget if the
-      // server is the same major as bundled OR older (no unknown migrations).
-      // If the server is newer than bundled, falling back to the bundled API
-      // would hit @actual-app/api's `out-of-sync-migrations` guard with an
-      // opaque error. Fail loud here instead so the user knows what to do.
-      if (compareSemver(serverVersion, bundledVersion) > 0) {
+      } else if (serverIsNewer) {
         throw new ApiVersionMismatchError(
           serverVersion,
           bundledVersion,
           downloadError ?? 'unknown download failure'
         )
+      } else {
+        logger.warn(
+          { serverVersion, bundledVersion, downloadError },
+          'Could not download matching @actual-app/api; falling back to bundled API'
+        )
       }
-
-      logger.warn(
-        { serverVersion, bundledVersion, downloadError },
-        'Could not download matching @actual-app/api; server is older than bundled, falling back to bundled API'
-      )
     } else {
       logger.debug(
         { version: bundledVersion },

--- a/src/actual-client.ts
+++ b/src/actual-client.ts
@@ -12,6 +12,27 @@ if (typeof globalThis.navigator === 'undefined') {
   globalThis.navigator = { userAgent: 'node' }
 }
 
+export class ApiVersionMismatchError extends Error {
+  readonly serverVersion: string
+  readonly bundledVersion: string
+  readonly downloadError: string
+
+  constructor(serverVersion: string, bundledVersion: string, downloadError: string) {
+    super(
+      [
+        `Actual Budget server is on ${serverVersion}, but this container ships @actual-app/api ${bundledVersion}.`,
+        `Tried to download a matching API at runtime, but it failed: ${downloadError}.`,
+        `Refusing to open the budget with the older bundled API — that would produce an "out-of-sync-migrations" error and could corrupt data.`,
+        `Fix: upgrade this container to a newer redbark-co/actual-sync image, or pin your Actual server to ${bundledVersion}.`,
+      ].join(' ')
+    )
+    this.name = 'ApiVersionMismatchError'
+    this.serverVersion = serverVersion
+    this.bundledVersion = bundledVersion
+    this.downloadError = downloadError
+  }
+}
+
 interface ActualConfig {
   serverUrl: string
   password: string
@@ -48,19 +69,20 @@ async function getServerVersion(serverUrl: string): Promise<string | null> {
   }
 }
 
-/**
- * Download a specific version of @actual-app/api from npm into the data directory.
- * Returns the path to the installed package, or null if it fails.
- */
-function downloadMatchingApi(
-  version: string,
-  dataDir: string
-): string | null {
+interface DownloadResult {
+  path: string | null
+  error: string | null
+}
+
+function downloadMatchingApi(version: string, dataDir: string): DownloadResult {
   const pkgDir = join(dataDir, `actual-api-${version}`)
 
   if (existsSync(join(pkgDir, 'node_modules', '@actual-app', 'api'))) {
     logger.debug({ version, pkgDir }, 'Using cached @actual-app/api')
-    return join(pkgDir, 'node_modules', '@actual-app', 'api')
+    return {
+      path: join(pkgDir, 'node_modules', '@actual-app', 'api'),
+      error: null,
+    }
   }
 
   logger.info(
@@ -71,7 +93,6 @@ function downloadMatchingApi(
   try {
     mkdirSync(pkgDir, { recursive: true })
 
-    // Write a minimal package.json so npm install works
     const pkgJson = JSON.stringify({
       name: 'actual-api-loader',
       private: true,
@@ -88,17 +109,40 @@ function downloadMatchingApi(
     const apiPath = join(pkgDir, 'node_modules', '@actual-app', 'api')
     if (existsSync(apiPath)) {
       logger.info({ version }, 'Successfully installed matching @actual-app/api')
-      return apiPath
+      return { path: apiPath, error: null }
     }
 
-    return null
+    return { path: null, error: 'npm install completed but package not found' }
   } catch (error) {
-    logger.warn(
-      { version, error: String(error) },
-      'Failed to download matching @actual-app/api, falling back to bundled version'
-    )
-    return null
+    return { path: null, error: extractNpmError(error) }
   }
+}
+
+function extractNpmError(error: unknown): string {
+  const raw = error instanceof Error ? (error.message ?? String(error)) : String(error)
+  // execSync surfaces both stdout and stderr inside Error.message; pluck the
+  // most informative line so the user sees the actual failure, not a wall of
+  // node-gyp output.
+  if (raw.includes('Could not find any Python installation')) {
+    return 'native build toolchain missing (python3 not available) — better-sqlite3 has no prebuilt binary for this Node ABI/arch and cannot be compiled from source in this container'
+  }
+  if (raw.includes('prebuild-install')) {
+    const match = raw.match(/No prebuilt binaries found[^\n]*/)
+    if (match) return match[0]
+  }
+  return raw.split('\n').slice(0, 3).join(' ').slice(0, 500)
+}
+
+function compareSemver(a: string, b: string): number {
+  const parse = (v: string) =>
+    v.split('-')[0]!.split('.').map((p) => Number.parseInt(p, 10) || 0)
+  const [pa, pb] = [parse(a), parse(b)]
+  for (let i = 0; i < Math.max(pa.length, pb.length); i++) {
+    const da = pa[i] ?? 0
+    const db = pb[i] ?? 0
+    if (da !== db) return da < db ? -1 : 1
+  }
+  return 0
 }
 
 /**
@@ -144,17 +188,39 @@ async function loadActualApi(
         'Actual Budget server version differs from bundled API'
       )
 
-      const matchingPath = downloadMatchingApi(serverVersion, dataDir)
+      const { path: matchingPath, error: downloadError } = downloadMatchingApi(
+        serverVersion,
+        dataDir
+      )
       if (matchingPath) {
         try {
           return require(matchingPath) as typeof import('@actual-app/api')
         } catch (error) {
-          logger.warn(
-            { error: String(error) },
-            'Failed to load downloaded API, using bundled version'
+          throw new ApiVersionMismatchError(
+            serverVersion,
+            bundledVersion,
+            `loaded downloaded API at ${matchingPath} but require() failed: ${String(error)}`
           )
         }
       }
+
+      // Download failed. Bundled API can still safely open a budget if the
+      // server is the same major as bundled OR older (no unknown migrations).
+      // If the server is newer than bundled, falling back to the bundled API
+      // would hit @actual-app/api's `out-of-sync-migrations` guard with an
+      // opaque error. Fail loud here instead so the user knows what to do.
+      if (compareSemver(serverVersion, bundledVersion) > 0) {
+        throw new ApiVersionMismatchError(
+          serverVersion,
+          bundledVersion,
+          downloadError ?? 'unknown download failure'
+        )
+      }
+
+      logger.warn(
+        { serverVersion, bundledVersion, downloadError },
+        'Could not download matching @actual-app/api; server is older than bundled, falling back to bundled API'
+      )
     } else {
       logger.debug(
         { version: bundledVersion },

--- a/src/main.ts
+++ b/src/main.ts
@@ -1,7 +1,7 @@
 import { logger } from './logger.js'
 import { loadConfig, ConfigError } from './config.js'
 import { RedbarkClient } from './redbark-client.js'
-import { listActualAccounts } from './actual-client.js'
+import { ApiVersionMismatchError, listActualAccounts } from './actual-client.js'
 import { runSync } from './sync.js'
 
 // Exit codes
@@ -9,6 +9,7 @@ const EXIT_SUCCESS = 0
 const EXIT_SYNC_ERRORS = 1
 const EXIT_CONFIG_ERROR = 2
 const EXIT_CONNECTION_ERROR = 3
+const EXIT_VERSION_MISMATCH = 4
 
 interface CliFlags {
   listRedbarkAccounts: boolean
@@ -276,6 +277,18 @@ main().catch((error) => {
   if (error instanceof ConfigError) {
     console.error(`ERROR: ${error.message}`)
     process.exit(EXIT_CONFIG_ERROR)
+  }
+
+  if (error instanceof ApiVersionMismatchError) {
+    logger.error(
+      {
+        serverVersion: error.serverVersion,
+        bundledVersion: error.bundledVersion,
+        downloadError: error.downloadError,
+      },
+      error.message
+    )
+    process.exit(EXIT_VERSION_MISMATCH)
   }
 
   if (


### PR DESCRIPTION
Fixes #14.

## What was happening

The reporter's container was running an older bundled `@actual-app/api` (26.4.0) against an Actual server on 26.5.2. The runtime version-matching path detected the mismatch and tried to `npm install @actual-app/api@26.5.2` into the data dir, but:

- `better-sqlite3` has no prebuilt binary for the user's Node ABI / musl / x64 combination
- `prebuild-install` fell through to `node-gyp rebuild`
- the runner Docker stage has no `python3`, so `node-gyp` died with "Could not find any Python installation"

The download error was caught and swallowed; we fell back to the bundled 26.4.0. The bundled API then tried to open a DB that had been forward-migrated by 26.5.2 (migrations like `add_tags`, `multiple_dashboards`, `add_payee_locations`) and hit @actual-app/api's `checkDatabaseValidity` → opaque `out-of-sync-migrations` throw with no actionable guidance.

## Fix

The bundled fallback is only safe when the server is the **same major as bundled or older** — it has all the migrations the server's DB could contain. When the server is **newer**, falling back is guaranteed to fail (and unsafe to attempt).

Changes:

- `downloadMatchingApi` now returns a `{ path, error }` result so callers can surface the real failure reason
- `extractNpmError` collapses the npm/node-gyp wall-of-output into a single actionable line (e.g. "native build toolchain missing")
- new `ApiVersionMismatchError` thrown in `loadActualApi` when the server is strictly newer than bundled and the download didn't succeed. Message includes the two versions, the download failure reason, and a recommended fix ("upgrade this container, or pin your Actual server to {bundled}")
- `main.ts` maps the new error to a dedicated exit code `4` for orchestrators
- README exit-code table updated

The older-server case (server ≤ bundled) keeps the existing silent fallback to the bundled API since the bundled API has every migration the server might write.

## Out of scope (deliberately)

Not adding `python3 make g++` to the runner stage. The matching mechanism is best-effort and most users hit it via prebuilt binaries successfully; adding ~50 MB of build toolchain to every image to cover a corner case feels disproportionate. The new error makes the corner case self-diagnosing — the user is told exactly which container/server versions are in play.

## Test plan

- [ ] Build the image and confirm it still starts when bundled and server versions match
- [ ] Simulate an old container against a newer server (or temporarily fake the bundled version) and confirm the new error message renders, exits 4, and does not attempt to open the budget